### PR TITLE
#31-getItemCount 메소드 구현 추가

### DIFF
--- a/app/src/main/java/me/plic/playholic/common/adapter/BaseRecyclerViewAdapter.kt
+++ b/app/src/main/java/me/plic/playholic/common/adapter/BaseRecyclerViewAdapter.kt
@@ -13,7 +13,6 @@ abstract class BaseRecyclerViewAdapter<T : Any, H : RecyclerView.ViewHolder> : R
         notifyItemChanged(itemList.size - 1)
     }
 
-
     fun addItems(dataSet: List<T>) {
         itemList.addAll(dataSet)
 
@@ -37,5 +36,8 @@ abstract class BaseRecyclerViewAdapter<T : Any, H : RecyclerView.ViewHolder> : R
         return itemList[positon]
     }
 
+    override fun getItemCount(): Int {
+        return itemList.size
+    }
 
 }


### PR DESCRIPTION
`getItemCount` 메소드 구현을 추가함.

리스트는 항상 null 이 아니므로, size를 그대로 반환하게 함.