### PR TITLE
#121-프래그먼트 replace 코드 수정

### DIFF
--- a/app/src/main/java/me/plic/playholic/common/ActivityHelper.kt
+++ b/app/src/main/java/me/plic/playholic/common/ActivityHelper.kt
@@ -1,0 +1,8 @@
+package me.plic.playholic.common
+
+import android.support.v4.app.Fragment
+
+interface ActivityHelper  {
+
+    fun replaceFragmentToActivity(fragment : Fragment)
+}

--- a/app/src/main/java/me/plic/playholic/common/SwitchScreen.kt
+++ b/app/src/main/java/me/plic/playholic/common/SwitchScreen.kt
@@ -1,7 +1,0 @@
-package me.plic.playholic.common
-
-interface SwitchScreen {
-
-    fun applyFragment()
-
-}

--- a/app/src/main/java/me/plic/playholic/ui/main/MainFragment.kt
+++ b/app/src/main/java/me/plic/playholic/ui/main/MainFragment.kt
@@ -8,13 +8,12 @@ import android.support.v7.widget.LinearLayoutManager
 import android.view.*
 import me.plic.playholic.R
 import me.plic.playholic.bucket.BucketViewModel
-import me.plic.playholic.common.SwitchScreen
+import me.plic.playholic.common.ActivityHelper
 import me.plic.playholic.databinding.FragmentMainBinding
 import me.plic.playholic.mypage.MyPageFragment
 import me.plic.playholic.ticket.TicketViewModel
-import me.plic.playholic.ui.history.HistoryFragment
 
-class MainFragment : Fragment(), SwitchScreen {
+class MainFragment : Fragment(), ActivityHelper {
 
     lateinit var binding: FragmentMainBinding
 
@@ -33,7 +32,7 @@ class MainFragment : Fragment(), SwitchScreen {
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         when (item?.itemId) {
             R.id.menu_my -> {
-                goToMyPage()
+                replaceFragmentToActivity(MyPageFragment())
                 return true
             }
         }
@@ -46,8 +45,7 @@ class MainFragment : Fragment(), SwitchScreen {
         binding.viewModel = ViewModelProviders.of(this)
                 .get(MainFragmentViewModel::class.java)
                 .apply {
-                    switchScreen = this@MainFragment
-                    fgManager = this@MainFragment.fragmentManager
+                    activityHelper = this@MainFragment
                 }
 
         binding.ticketViewModel = TicketViewModel()
@@ -88,27 +86,15 @@ class MainFragment : Fragment(), SwitchScreen {
         }
     }
 
-    private fun goToMyPage() {
-        activity?.apply {
-            supportFragmentManager
-                    .beginTransaction()
-                    .replace(R.id.frame_main, MyPageFragment())
-                    .addToBackStack(null)
-                    .commit()
-        }
-    }
-
     /**
      * 새로운 프래그먼트로 교체하며 현재 프래그먼트를 백스택에 추가
      */
-    override fun applyFragment() {
-        activity?.apply {
-            supportFragmentManager
-                    .beginTransaction()
-                    .replace(R.id.frame_main, HistoryFragment())
-                    .addToBackStack(null)
-                    .commit()
-        }
+    override fun replaceFragmentToActivity(fragment : Fragment) {
+        me.plic.playholic.util.replaceFragmentToActivity(
+                activity?.supportFragmentManager,
+                fragment,
+                R.id.frame_main
+        )
     }
 
 }

--- a/app/src/main/java/me/plic/playholic/ui/main/MainFragmentViewModel.kt
+++ b/app/src/main/java/me/plic/playholic/ui/main/MainFragmentViewModel.kt
@@ -1,36 +1,31 @@
 package me.plic.playholic.ui.main
 
 import android.arch.lifecycle.ViewModel
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
 import android.view.View
 import me.plic.playholic.R
-import me.plic.playholic.common.SwitchScreen
+import me.plic.playholic.common.ActivityHelper
+import me.plic.playholic.ui.history.HistoryFragment
 import me.plic.playholic.ui.wish.WishFragment
 
 class MainFragmentViewModel : ViewModel() {
 
-    lateinit var switchScreen: SwitchScreen
-    var fgManager: FragmentManager? = null
+    lateinit var activityHelper: ActivityHelper
 
-    fun applyFragment() {
-        if (::switchScreen.isInitialized) switchScreen.applyFragment()
-        else throw UninitializedPropertyAccessException("switchScreen is not initialized")
+    //Check activityHelper is initialized.
+    private fun isActivityHelperInitialized() = (::activityHelper.isInitialized)
+
+
+    fun onHistoryButtonClick() {
+        if (isActivityHelperInitialized()) {
+            activityHelper.replaceFragmentToActivity(HistoryFragment())
+        }
     }
 
     fun onFABClick(view: View) {
-        when (view.id) {
-            R.id.fab_wish -> applyFragment(WishFragment())
-        }
-
-    }
-
-    private fun applyFragment(fragment: Fragment) {
-        fgManager?.apply {
-            beginTransaction()
-                    .replace(R.id.frame_main, WishFragment())
-                    .addToBackStack(null)
-                    .commit()
+        if (isActivityHelperInitialized()) {
+            when (view.id) {
+                R.id.fab_wish -> activityHelper.replaceFragmentToActivity(WishFragment())
+            }
         }
     }
 }

--- a/app/src/main/java/me/plic/playholic/util/ActivityUtils.kt
+++ b/app/src/main/java/me/plic/playholic/util/ActivityUtils.kt
@@ -1,0 +1,21 @@
+package me.plic.playholic.util
+
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+
+/**
+ * In Util class, Every method is being static.
+ */
+fun replaceFragmentToActivity(
+        fragmentManager: FragmentManager?,
+        fragment: Fragment,
+        frameId: Int) {
+
+    checkNotNull(fragmentManager)
+            .beginTransaction().apply {
+                replace(frameId, fragment)
+                addToBackStack(null)
+                commit()
+            }
+}
+

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -95,7 +95,7 @@
             android:background = "@drawable/border_round_purple_05"
             android:drawableEnd = "@drawable/ic_chevron_right_primary_24dp"
             android:gravity = "center"
-            android:onClick = "@{() -> viewModel.applyFragment()}"
+            android:onClick = "@{() -> viewModel.onHistoryButtonClick()}"
             android:paddingBottom = "2dp"
             android:paddingEnd = "3dp"
             android:paddingStart = "9dp"


### PR DESCRIPTION
1. 실제 로직이 담긴 `ActivityUtils`클래스 생성 후 프래그먼트를 replace하는 메소드를 구현함.
2. 이 메소드 호출의 중간 역할을 하는 `ActivityHelper` 인터페이스를 생성 후 `Fragment`만 인자로 받는 메소드를 선언함.
3. `MainFragment`가 2. 의 인터페이스를 implements 하도록 하며 오버라이딩 한 메소드 내에는 `ActivityUtils`클래스의 `replaceFragmentToActivity` 메소드를 호출하도록 함.
4. `MainFragmentViewModel`에서 `ActivityHelper`인터페이스의 `replaceFragmentToActivity`메소드를 호출하도록 함. 이 때 교체할 프래그먼트를 인자로 보냄.