### PR TITLE
#160-Comment adapter 클래스 추가

### DIFF
--- a/app/src/main/java/me/plic/playholic/ui/comment/adapter/CommentAdapter.kt
+++ b/app/src/main/java/me/plic/playholic/ui/comment/adapter/CommentAdapter.kt
@@ -1,0 +1,27 @@
+package me.plic.playholic.ui.comment.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import io.reactivex.subjects.PublishSubject
+import me.plic.playholic.R
+import me.plic.playholic.common.adapter.BaseRecyclerViewAdapter
+import me.plic.playholic.data.Comment
+import me.plic.playholic.ui.comment.viewHolder.CommentViewHolder
+
+class CommentAdapter : BaseRecyclerViewAdapter<me.plic.playholic.data.Comment, CommentViewHolder>() {
+
+    val clickSubject : PublishSubject<Comment> = PublishSubject.create()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentViewHolder {
+        return CommentViewHolder(
+                LayoutInflater.from(parent.context)
+                        .inflate(R.layout.item_comment, parent, false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
+        getItem(position).let {
+            holder.getClickObservable(it).subscribe(clickSubject)
+        }
+    }
+}

--- a/app/src/main/java/me/plic/playholic/ui/comment/viewHolder/CommentViewHolder.kt
+++ b/app/src/main/java/me/plic/playholic/ui/comment/viewHolder/CommentViewHolder.kt
@@ -1,0 +1,22 @@
+package me.plic.playholic.ui.comment.viewHolder
+
+import android.databinding.DataBindingUtil
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import io.reactivex.Observable
+import me.plic.playholic.data.Comment
+import me.plic.playholic.databinding.ItemCommentBinding
+
+
+class CommentViewHolder(itemView : View) : RecyclerView.ViewHolder(itemView) {
+
+    val binding : ItemCommentBinding? = DataBindingUtil.bind(itemView)
+
+    fun getClickObservable(item : Comment) : Observable<Comment> {
+        return Observable.create { emitter ->
+            itemView.setOnClickListener {
+                emitter.onNext(item)
+            }
+        }
+    }
+}


### PR DESCRIPTION
`CommentAdapter`클래스
`CommentViewHolder` 클래스 추가함.

Comment 아이템 클릭 시 전체 내용을 보여주는 화면으로 이동하므로 
`Observable`을 반환하는 메소드를 `CommentViewHolder`클래스에 구현함.